### PR TITLE
test: Playwright e2e for Tabs (V8 coverage, PR CI)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,34 @@
+name: e2e
+
+on:
+  pull_request:
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: pnpm --filter astro exec playwright install --with-deps chromium
+
+      - name: Run Tabs e2e tests
+        run: pnpm --filter astro test:e2e
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: apps/astro/playwright-report
+          retention-days: 7

--- a/apps/astro/.gitignore
+++ b/apps/astro/.gitignore
@@ -3,6 +3,12 @@ dist/
 # generated types
 .astro/
 
+# playwright + coverage
+test-results/
+playwright-report/
+coverage/
+e2e/.v8/
+
 # dependencies
 node_modules/
 

--- a/apps/astro/astro.config.mjs
+++ b/apps/astro/astro.config.mjs
@@ -6,4 +6,7 @@ import react from "@astrojs/react";
 // https://astro.build/config
 export default defineConfig({
   integrations: [react()],
+  // Emit source maps so Playwright V8 coverage maps the built _astro chunks
+  // back to the @repo/ds TypeScript sources.
+  vite: { build: { sourcemap: true } },
 });

--- a/apps/astro/e2e/generate-reports.mjs
+++ b/apps/astro/e2e/generate-reports.mjs
@@ -1,0 +1,70 @@
+// Converts the raw V8 coverage collected by the Playwright fixture into an
+// Istanbul report, mapped through source maps back to the @repo/ds Tabs source.
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import libCoverage from "istanbul-lib-coverage";
+import libReport from "istanbul-lib-report";
+import reports from "istanbul-reports";
+import v8toIstanbul from "v8-to-istanbul";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appDir = resolve(here, ".."); // apps/astro
+const repoRoot = resolve(appDir, "..", "..");
+const distDir = resolve(appDir, "dist");
+const v8Dir = resolve(here, ".v8");
+const outDir = resolve(appDir, "coverage", "e2e");
+
+// Report only the design-system Tabs source (drop React, Astro, vite client).
+const keep = (file) => {
+  const norm = file.replaceAll("\\", "/");
+  return (
+    norm.endsWith("packages/ds/components/tabs.tsx") ||
+    norm.endsWith("packages/ds/components/ds-tabs.ts")
+  );
+};
+
+async function main() {
+  if (!existsSync(v8Dir)) {
+    console.error("No coverage collected - run `pnpm test:e2e:coverage`.");
+    process.exit(1);
+  }
+
+  const map = libCoverage.createCoverageMap({});
+
+  for (const name of readdirSync(v8Dir).filter((n) => n.endsWith(".json"))) {
+    const entries = JSON.parse(readFileSync(resolve(v8Dir, name), "utf8"));
+    for (const entry of entries) {
+      const { pathname } = new URL(entry.url);
+      const filePath = resolve(distDir, `.${pathname}`); // /_astro/x.js -> dist/_astro/x.js
+      if (!existsSync(filePath)) continue;
+
+      const converter = v8toIstanbul(filePath, 0, { source: entry.source });
+      await converter.load();
+      converter.applyCoverage(entry.functions);
+
+      for (const [file, fileCov] of Object.entries(converter.toIstanbul())) {
+        if (keep(file)) map.addFileCoverage(fileCov);
+      }
+    }
+  }
+
+  const context = libReport.createContext({ dir: outDir, coverageMap: map });
+  reports.create("text-summary").execute(context);
+  reports.create("html").execute(context);
+  reports.create("lcovonly").execute(context);
+  reports.create("json-summary").execute(context);
+
+  rmSync(v8Dir, { recursive: true, force: true });
+  console.log(`\nCoverage report written to ${relative(repoRoot, outDir)}/`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/astro/e2e/helpers/fixture.ts
+++ b/apps/astro/e2e/helpers/fixture.ts
@@ -1,0 +1,47 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test as base, expect } from "@playwright/test";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const V8_DIR = resolve(here, "..", ".v8");
+
+// Overrides the built-in `page` fixture so every spec collects V8 coverage when
+// E2E_COVERAGE is set, writing one raw-V8 JSON per test for generate-reports.mjs
+// to convert. A no-op otherwise.
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    if (process.env.E2E_COVERAGE !== "true") {
+      await use(page);
+      return;
+    }
+    // startJSCoverage throws when JS is disabled (the no-JS specs); skip quietly.
+    let started = false;
+    try {
+      await page.coverage.startJSCoverage({ resetOnNavigation: false });
+      started = true;
+    } catch {
+      /* no coverage for this page */
+    }
+    await use(page);
+    if (!started) return;
+    const entries = await page.coverage.stopJSCoverage();
+    const appEntries = entries.filter((entry) => {
+      const { pathname } = new URL(entry.url);
+      return (
+        pathname.startsWith("/_astro/") && !pathname.includes("node_modules")
+      );
+    });
+    if (appEntries.length > 0) {
+      mkdirSync(V8_DIR, { recursive: true });
+      writeFileSync(
+        resolve(V8_DIR, `${randomUUID()}.json`),
+        JSON.stringify(appEntries),
+      );
+    }
+  },
+});
+
+export { expect };
+export type { Page } from "@playwright/test";

--- a/apps/astro/e2e/tests/tabs/composition.spec.ts
+++ b/apps/astro/e2e/tests/tabs/composition.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "../../helpers/fixture";
+
+// Two instances in one React tree with no explicit id.
+test.beforeEach(async ({ page }) => {
+  await page.goto("/test/composition");
+  await expect(page.locator("ds-tabs")).toHaveCount(2);
+});
+
+test("each instance gets a distinct radio-group name via useId", async ({
+  page,
+}) => {
+  const names = await page
+    .locator('ds-tabs input[type="radio"]')
+    .evaluateAll((els) =>
+      Array.from(new Set(els.map((el) => (el as HTMLInputElement).name))),
+    );
+  expect(names).toHaveLength(2);
+});
+
+test("the instances operate independently", async ({ page }) => {
+  const first = page.locator("ds-tabs").nth(0);
+  const second = page.locator("ds-tabs").nth(1);
+  await first.getByRole("tab", { name: "Settings" }).click();
+  await expect(first.getByRole("tab", { name: "Settings" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await expect(second.getByRole("tab", { name: "Account" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+});

--- a/apps/astro/e2e/tests/tabs/controlled.spec.ts
+++ b/apps/astro/e2e/tests/tabs/controlled.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from "../../helpers/fixture";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/test/controlled");
+  // Wait for React to hydrate - controlled behaviour is a hydration feature;
+  // the tablist alone only signals the custom-element upgrade.
+  await expect(page.locator('[data-testid="ctrl-cv"]')).toHaveAttribute(
+    "data-hydrated",
+    "true",
+  );
+  await expect(page.locator('[data-testid="ctrl-cs"]')).toHaveAttribute(
+    "data-hydrated",
+    "true",
+  );
+});
+
+test("the active tab reflects the controlled value", async ({ page }) => {
+  await expect(
+    page.locator('[data-testid="ctrl-cv"]').getByRole("tab", { name: "Account" }),
+  ).toHaveAttribute("aria-selected", "true");
+});
+
+test("a programmatic value change switches tab without echoing onValueChange", async ({
+  page,
+}) => {
+  await page.locator('[data-testid="cv-ext"]').click();
+  await expect(
+    page.locator('[data-testid="ctrl-cv"]').getByRole("tab", { name: "Settings" }),
+  ).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator('[data-testid="cv-value"]')).toHaveText("settings");
+  await expect(page.locator('[data-testid="cv-changes"]')).toHaveText("0");
+});
+
+test("user interaction is reported through onValueChange", async ({ page }) => {
+  await page
+    .locator('[data-testid="ctrl-cv"]')
+    .getByRole("tab", { name: "Documents" })
+    .click();
+  await expect(page.locator('[data-testid="cv-value"]')).toHaveText("documents");
+  await expect(page.locator('[data-testid="cv-changes"]')).toHaveText("1");
+  await expect(
+    page.locator('[data-testid="ctrl-cv"]').getByRole("tab", { name: "Documents" }),
+  ).toHaveAttribute("aria-selected", "true");
+});
+
+// The preHydration strategies ("ignore" vs "report") only diverge when a
+// user interacts with the no-JS fallback BEFORE the island hydrates; that race
+// is exercised in pre-hydration.spec.ts (by holding the island JS). Here we
+// just confirm the "report" instance mounts and is interactive once hydrated.
+test('"report" instance hydrates and is interactive', async ({ page }) => {
+  const d = page.locator('[data-testid="ctrl-cs"]');
+  await expect(d.getByRole("tab", { name: "Account" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await d.getByRole("tab", { name: "Settings" }).click();
+  await expect(page.locator('[data-testid="cs-value"]')).toHaveText("settings");
+});

--- a/apps/astro/e2e/tests/tabs/hydrated.spec.ts
+++ b/apps/astro/e2e/tests/tabs/hydrated.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "../../helpers/fixture";
+
+// React island (client:load) on top of the upgraded element.
+test.beforeEach(async ({ page }) => {
+  await page.goto("/test/hydrated");
+  await expect(page.locator('[data-testid="demo-h"]')).toHaveAttribute(
+    "data-hydrated",
+    "true",
+  );
+});
+
+test("does not call onValueChange on mount", async ({ page }) => {
+  await expect(page.locator('[data-testid="last-h"]')).toHaveText("");
+});
+
+test("calls onValueChange on a user change", async ({ page }) => {
+  await page
+    .locator('[data-testid="demo-h"]')
+    .getByRole("tab", { name: "Documents" })
+    .click();
+  await expect(page.locator('[data-testid="last-h"]')).toHaveText("documents");
+});
+
+test("vertical instance moves with Up/Down and ignores Left/Right", async ({
+  page,
+}) => {
+  const d = page.locator('[data-testid="demo-v"]');
+  const account = d.getByRole("tab", { name: "Account" });
+  await account.focus();
+  await page.keyboard.press("ArrowLeft"); // off-axis on a vertical tablist
+  await expect(account).toBeFocused();
+  await page.keyboard.press("ArrowDown");
+  await expect(d.getByRole("tab", { name: "Documents" })).toBeFocused();
+});
+
+test("instances are independent", async ({ page }) => {
+  await page
+    .locator('[data-testid="demo-h"]')
+    .getByRole("tab", { name: "Settings" })
+    .click();
+  await expect(
+    page.locator('[data-testid="demo-h"]').getByRole("tab", { name: "Settings" }),
+  ).toHaveAttribute("aria-selected", "true");
+  await expect(
+    page.locator('[data-testid="demo-v"]').getByRole("tab", { name: "Account" }),
+  ).toHaveAttribute("aria-selected", "true");
+});
+
+test("logs no hydration warnings or errors", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") errors.push(m.text());
+  });
+  page.on("pageerror", (e) => errors.push(String(e)));
+  await page.goto("/test/hydrated");
+  await expect(page.locator('[data-testid="demo-h"]')).toHaveAttribute(
+    "data-hydrated",
+    "true",
+  );
+  await page
+    .locator('[data-testid="demo-h"]')
+    .getByRole("tab", { name: "Documents" })
+    .click();
+  expect(errors).toEqual([]);
+});

--- a/apps/astro/e2e/tests/tabs/nested.spec.ts
+++ b/apps/astro/e2e/tests/tabs/nested.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "../../helpers/fixture";
+
+// Tabs within tabs: the inner Tabs.Root lives in the outer "account" panel.
+test.beforeEach(async ({ page }) => {
+  await page.goto("/test/tabs-nested");
+  await expect(page.locator('[data-testid="nested-tabs"]')).toHaveAttribute(
+    "data-hydrated",
+    "true",
+  );
+});
+
+test("inner tabs switch independently of the outer set", async ({ page }) => {
+  const inner = page.locator('[data-testid="inner"]');
+  // inner starts on Profile
+  await expect(inner.getByRole("tab", { name: "Profile" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await inner.getByRole("tab", { name: "Email" }).click();
+  await expect(inner.getByRole("tab", { name: "Email" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  // outer is unaffected: still on Account (the inner panel is still shown)
+  await expect(
+    page.getByRole("tab", { name: "Account" }).first(),
+  ).toHaveAttribute("aria-selected", "true");
+});
+
+test("inner tablist is only present while its outer tab is active", async ({
+  page,
+}) => {
+  await expect(page.locator('[data-testid="inner"] [role="tab"]')).toHaveCount(
+    2,
+  );
+  await page.getByRole("tab", { name: "Settings" }).first().click();
+  // outer switched away from Account; the inner panel (and its tabs) is hidden
+  await expect(page.locator('[data-testid="inner"]')).toBeHidden();
+});
+
+test("the two instances use distinct radio-group names (no collision)", async ({
+  page,
+}) => {
+  const names = await page
+    .locator('[data-testid="nested-tabs"] input[type="radio"]')
+    .evaluateAll((els) =>
+      Array.from(new Set(els.map((el) => (el as HTMLInputElement).name))),
+    );
+  // outer (2 tabs) + inner (2 tabs) => two distinct names
+  expect(names).toHaveLength(2);
+});

--- a/apps/astro/e2e/tests/tabs/no-js.spec.ts
+++ b/apps/astro/e2e/tests/tabs/no-js.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "../../helpers/fixture";
+
+// No JavaScript at all: only the SSR radio-group fallback exists.
+test.use({ javaScriptEnabled: false });
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/test/hydrated");
+});
+
+test("shows exactly one panel - the checked radio's", async ({ page }) => {
+  const demo = page.locator('[data-testid="demo-h"]');
+  await expect(
+    demo.locator('[data-tabs-content][data-value="account"]'),
+  ).toBeVisible();
+  await expect(
+    demo.locator('[data-tabs-content][data-value="documents"]'),
+  ).toBeHidden();
+  await expect(
+    demo.locator('[data-tabs-content][data-value="settings"]'),
+  ).toBeHidden();
+});
+
+test("the initially visible panel is the default", async ({ page }) => {
+  await expect(page.locator("#h-account")).toBeChecked();
+});
+
+test("selecting a tab switches the panel without touching the URL", async ({
+  page,
+}) => {
+  const url = page.url();
+  await page.locator('[data-testid="demo-h"] label[for="h-documents"]').click();
+  const demo = page.locator('[data-testid="demo-h"]');
+  await expect(
+    demo.locator('[data-tabs-content][data-value="documents"]'),
+  ).toBeVisible();
+  await expect(
+    demo.locator('[data-tabs-content][data-value="account"]'),
+  ).toBeHidden();
+  expect(page.url()).toBe(url);
+});
+
+test("exposes no tablist roles before upgrade", async ({ page }) => {
+  await expect(page.locator('[role="tablist"]')).toHaveCount(0);
+});
+
+test("radios are excluded from form submission (null form owner)", async ({
+  page,
+}) => {
+  await expect(page.locator("#h-account")).toHaveAttribute("form", "h-none");
+  await expect(page.locator("form#h-none")).toHaveCount(0);
+});
+
+test("instances use distinct radio-group names (no cross-talk)", async ({
+  page,
+}) => {
+  await expect(
+    page.locator('[data-testid="demo-h"] input[type="radio"]').first(),
+  ).toHaveAttribute("name", "h");
+  await expect(
+    page.locator('[data-testid="demo-v"] input[type="radio"]').first(),
+  ).toHaveAttribute("name", "v");
+});

--- a/apps/astro/e2e/tests/tabs/pre-hydration.spec.ts
+++ b/apps/astro/e2e/tests/tabs/pre-hydration.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect, type Page } from "../../helpers/fixture";
+
+// Holds every island/define JS chunk until release(), so a test can interact
+// with the no-JS radio fallback BEFORE React hydrates, then let it hydrate and
+// assert the selection is handed off.
+async function gateIslandJs(page: Page) {
+  let release = () => {};
+  const gate = new Promise<void>((resolve) => (release = resolve));
+  await page.route(
+    (url) => url.pathname.includes("/_astro/") && url.pathname.endsWith(".js"),
+    async (route) => {
+      await gate;
+      await route.continue();
+    },
+  );
+  return { release: () => release() };
+}
+
+test("uncontrolled: a selection made before hydration is reported via onValueChange", async ({
+  page,
+}) => {
+  const { release } = await gateIslandJs(page);
+  await page.goto("/test/hydrated", { waitUntil: "commit" });
+
+  // Pick a non-default tab via the native radio fallback (no JS yet).
+  await page.locator('[data-testid="demo-h"] label[for="h-settings"]').click();
+  await expect(page.locator("#h-settings")).toBeChecked();
+
+  release(); // let the island + define script load and hydrate
+  await expect(page.locator('[data-testid="demo-h"]')).toHaveAttribute(
+    "data-hydrated",
+    "true",
+  );
+  // The pre-hydration pick differs from defaultValue, so it is handed off.
+  await expect(page.locator('[data-testid="last-h"]')).toHaveText("settings");
+});
+
+test('controlled "report": a pre-hydration pick is adopted over the value', async ({
+  page,
+}) => {
+  const { release } = await gateIslandJs(page);
+  await page.goto("/test/controlled", { waitUntil: "commit" });
+
+  // Controlled value is "account"; pick "settings" before hydration.
+  await page.locator('[data-testid="ctrl-cs"] label[for="cs-settings"]').click();
+  await expect(page.locator("#cs-settings")).toBeChecked();
+
+  release();
+  await expect(page.locator('[data-testid="ctrl-cs"]')).toHaveAttribute(
+    "data-hydrated",
+    "true",
+  );
+  // "report" reports the pick via onValueChange, so the consumer adopts it.
+  await expect(page.locator('[data-testid="cs-value"]')).toHaveText("settings");
+});

--- a/apps/astro/e2e/tests/tabs/upgraded.spec.ts
+++ b/apps/astro/e2e/tests/tabs/upgraded.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect, type Page } from "../../helpers/fixture";
+
+// Custom element upgraded by the define script, but React never hydrates
+// (the page renders TabsDemo with no client directive).
+test.beforeEach(async ({ page }) => {
+  await page.goto("/test/upgraded");
+  await page.waitForFunction(() => !!customElements.get("ds-tabs"));
+});
+
+const demo = (page: Page) => page.locator('[data-testid="demo-up"]');
+
+test("upgrades the list to a tablist with aria-orientation", async ({
+  page,
+}) => {
+  const list = demo(page).locator('[role="tablist"]');
+  await expect(list).toBeVisible();
+  await expect(list).toHaveAttribute("aria-orientation", "horizontal");
+});
+
+test("assigns roles, roving tabindex, and one visible panel", async ({
+  page,
+}) => {
+  const d = demo(page);
+  await expect(d.getByRole("tab")).toHaveCount(3);
+  await expect(d.getByRole("tabpanel")).toHaveCount(1); // hidden panels excluded
+  const account = d.getByRole("tab", { name: "Account" });
+  await expect(account).toHaveAttribute("aria-selected", "true");
+  await expect(account).toHaveAttribute("tabindex", "0");
+  await expect(account).toHaveAttribute("data-state", "active");
+  await expect(d.getByRole("tab", { name: "Documents" })).toHaveAttribute(
+    "tabindex",
+    "-1",
+  );
+});
+
+test("links the active tab and panel via aria-controls/labelledby", async ({
+  page,
+}) => {
+  const tab = demo(page).getByRole("tab", { name: "Documents" });
+  await tab.click();
+  const panelId = await tab.getAttribute("aria-controls");
+  const tabId = await tab.getAttribute("id");
+  const panel = page.locator(`#${panelId}`);
+  await expect(panel).toBeVisible();
+  await expect(panel).toHaveAttribute("aria-labelledby", tabId ?? "");
+});
+
+test("arrow keys move along the horizontal axis; Home/End jump", async ({
+  page,
+}) => {
+  const d = demo(page);
+  await d.getByRole("tab", { name: "Account" }).focus();
+  await page.keyboard.press("ArrowRight");
+  await expect(d.getByRole("tab", { name: "Documents" })).toBeFocused();
+  await expect(d.getByRole("tab", { name: "Documents" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await page.keyboard.press("End");
+  await expect(d.getByRole("tab", { name: "Settings" })).toBeFocused();
+  await page.keyboard.press("Home");
+  await expect(d.getByRole("tab", { name: "Account" })).toBeFocused();
+  await page.keyboard.press("ArrowLeft"); // previous, wrapping to the last
+  await expect(d.getByRole("tab", { name: "Settings" })).toBeFocused();
+});
+
+test("ignores off-axis arrows on a horizontal tablist", async ({ page }) => {
+  const account = demo(page).getByRole("tab", { name: "Account" });
+  await account.focus();
+  await page.keyboard.press("ArrowDown");
+  await expect(account).toBeFocused();
+  await expect(account).toHaveAttribute("aria-selected", "true");
+});
+
+test("seeds the initial tab from the checked radio (beats default/first)", async ({
+  page,
+}) => {
+  await page.evaluate(() => {
+    const host = document.createElement("div");
+    host.id = "inject-pick";
+    host.innerHTML = `<ds-tabs><div data-tabs-list><label data-tabs-trigger data-value="a">A</label><label data-tabs-trigger data-value="b">B</label></div><div data-tabs-content data-value="a"><input type="radio" name="pk" value="a"></div><div data-tabs-content data-value="b"><input type="radio" name="pk" value="b" checked></div></ds-tabs>`;
+    document.body.appendChild(host);
+  });
+  await expect(
+    page.locator("#inject-pick").getByRole("tab", { name: "B" }),
+  ).toHaveAttribute("aria-selected", "true");
+});
+
+test("falls back to the first trigger when nothing else selects one", async ({
+  page,
+}) => {
+  await page.evaluate(() => {
+    const host = document.createElement("div");
+    host.id = "inject-first";
+    // No value, no default-value, no checked radio -> first trigger wins.
+    host.innerHTML = `<ds-tabs><div data-tabs-list><label data-tabs-trigger data-value="a">A</label><label data-tabs-trigger data-value="b">B</label></div><div data-tabs-content data-value="a"><input type="radio" name="fb" value="a"></div><div data-tabs-content data-value="b"><input type="radio" name="fb" value="b"></div></ds-tabs>`;
+    document.body.appendChild(host);
+  });
+  await expect(
+    page.locator("#inject-first").getByRole("tab", { name: "A" }),
+  ).toHaveAttribute("aria-selected", "true");
+});
+
+test("no change event on initial activation; re-selection is deduped", async ({
+  page,
+}) => {
+  await page.evaluate(() => {
+    (window as unknown as { __changes: string[] }).__changes = [];
+    const host = document.createElement("div");
+    host.id = "inject-evt";
+    host.addEventListener("ds-tabs:change", (e) =>
+      (window as unknown as { __changes: string[] }).__changes.push(
+        (e as CustomEvent<{ value: string }>).detail.value,
+      ),
+    );
+    host.innerHTML = `<ds-tabs default-value="a"><div data-tabs-list><label data-tabs-trigger data-value="a" for="ev-a">A</label><label data-tabs-trigger data-value="b" for="ev-b">B</label></div><div data-tabs-content data-value="a"><input type="radio" name="ev" id="ev-a" value="a"></div><div data-tabs-content data-value="b"><input type="radio" name="ev" id="ev-b" value="b"></div></ds-tabs>`;
+    document.body.appendChild(host);
+  });
+  const host = page.locator("#inject-evt");
+  await expect(host.getByRole("tab", { name: "A" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  const changes = () =>
+    page.evaluate(
+      () => (window as unknown as { __changes: string[] }).__changes,
+    );
+  expect(await changes()).toEqual([]); // none on initial
+  await host.getByRole("tab", { name: "B" }).click();
+  expect(await changes()).toEqual(["b"]);
+  await host.getByRole("tab", { name: "B" }).click(); // re-select active
+  expect(await changes()).toEqual(["b"]);
+});
+
+test("upgrades once triggers appear later (MutationObserver)", async ({
+  page,
+}) => {
+  await page.evaluate(() => {
+    const el = document.createElement("ds-tabs");
+    const host = document.createElement("div");
+    host.id = "inject-late";
+    host.appendChild(el);
+    document.body.appendChild(host);
+    setTimeout(() => {
+      el.innerHTML = `<div data-tabs-list><label data-tabs-trigger data-value="a">A</label></div><div data-tabs-content data-value="a"><input type="radio"></div>`;
+    }, 50);
+  });
+  await expect(page.locator("#inject-late [role='tablist']")).toBeVisible();
+});

--- a/apps/astro/package.json
+++ b/apps/astro/package.json
@@ -6,7 +6,9 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test:e2e": "playwright test",
+    "test:e2e:coverage": "E2E_COVERAGE=true playwright test; node e2e/generate-reports.mjs"
   },
   "dependencies": {
     "@astrojs/react": "^5.0.7",
@@ -16,5 +18,13 @@
     "astro": "^6.4.8",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1",
+    "istanbul-lib-coverage": "^3.2.2",
+    "istanbul-lib-report": "^3.0.1",
+    "istanbul-reports": "^3.2.0",
+    "playwright": "^1.59.1",
+    "v8-to-istanbul": "^9.3.0"
   }
 }

--- a/apps/astro/playwright.config.ts
+++ b/apps/astro/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Always test the production build via `astro preview` (the shipped artifact,
+// with the _astro chunks the coverage mapping and the pre-hydration route
+// matcher both rely on). Coverage collection is toggled by E2E_COVERAGE in the
+// fixture, not by the server mode.
+
+export default defineConfig({
+  testDir: "./e2e/tests",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: "http://localhost:4321",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "pnpm build && pnpm preview",
+    url: "http://localhost:4321",
+    reuseExistingServer: false,
+    timeout: 120_000,
+    gracefulShutdown: { signal: "SIGTERM", timeout: 10_000 },
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/apps/astro/src/components/ControlledTabs.tsx
+++ b/apps/astro/src/components/ControlledTabs.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { Tabs } from "@repo/ds";
+
+const ITEMS = [
+  { value: "account", label: "Account", body: "Make changes to your account." },
+  {
+    value: "documents",
+    label: "Documents",
+    body: "Access and update your documents.",
+  },
+  {
+    value: "settings",
+    label: "Settings",
+    body: "Edit your profile or update contact information.",
+  },
+];
+
+// Controlled Tabs demo. `value` is owned by React state; an external button
+// drives it programmatically. `changes` counts onValueChange calls so tests can
+// tell user interaction (fires) from a programmatic value change (does not).
+export default function ControlledTabs({
+  id,
+  preHydration,
+}: {
+  id: string;
+  preHydration: "ignore" | "report";
+}) {
+  const [value, setValue] = useState("account");
+  const [changes, setChanges] = useState(0);
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  return (
+    <div data-testid={`ctrl-${id}`} data-hydrated={hydrated ? "true" : "false"}>
+      <button
+        type="button"
+        data-testid={`${id}-ext`}
+        onClick={() => setValue("settings")}
+      >
+        Set settings externally
+      </button>
+      <p data-testid={`${id}-value`}>{value}</p>
+      <p data-testid={`${id}-changes`}>{changes}</p>
+      <Tabs.Root
+        id={id}
+        value={value}
+        preHydration={preHydration}
+        onValueChange={(next) => {
+          setValue(next);
+          setChanges((count) => count + 1);
+        }}
+      >
+        <Tabs.List>
+          {ITEMS.map((item) => (
+            <Tabs.Trigger key={item.value} id={id} value={item.value}>
+              {item.label}
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
+        <div>
+          {ITEMS.map((item) => (
+            <Tabs.Content key={item.value} id={id} value={item.value}>
+              {item.body}
+            </Tabs.Content>
+          ))}
+        </div>
+      </Tabs.Root>
+    </div>
+  );
+}

--- a/apps/astro/src/components/MultiDemo.tsx
+++ b/apps/astro/src/components/MultiDemo.tsx
@@ -1,0 +1,12 @@
+import TabsDemo from "./TabsDemo";
+
+// Two instances in ONE React tree with no explicit id: useId() must give each a
+// distinct base so they stay independent.
+export default function MultiDemo() {
+  return (
+    <div>
+      <TabsDemo />
+      <TabsDemo />
+    </div>
+  );
+}

--- a/apps/astro/src/components/NestedTabsDemo.tsx
+++ b/apps/astro/src/components/NestedTabsDemo.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { Tabs } from "@repo/ds";
+
+// Tabs within tabs: the "account" panel of the outer set contains an inner
+// Tabs.Root. Both are uncontrolled; useId gives each a distinct base so they
+// don't collide or cross-talk.
+export default function NestedTabsDemo() {
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  return (
+    <div data-testid="nested-tabs" data-hydrated={hydrated ? "true" : "false"}>
+      <Tabs.Root defaultValue="account">
+        <Tabs.List>
+          <Tabs.Trigger value="account">Account</Tabs.Trigger>
+          <Tabs.Trigger value="settings">Settings</Tabs.Trigger>
+        </Tabs.List>
+        <div>
+          <Tabs.Content value="account">
+            <p>Outer account panel.</p>
+            <div data-testid="inner">
+              <Tabs.Root defaultValue="profile">
+                <Tabs.List>
+                  <Tabs.Trigger value="profile">Profile</Tabs.Trigger>
+                  <Tabs.Trigger value="email">Email</Tabs.Trigger>
+                </Tabs.List>
+                <div>
+                  <Tabs.Content value="profile">Inner profile.</Tabs.Content>
+                  <Tabs.Content value="email">Inner email.</Tabs.Content>
+                </div>
+              </Tabs.Root>
+            </div>
+          </Tabs.Content>
+          <Tabs.Content value="settings">Outer settings panel.</Tabs.Content>
+        </div>
+      </Tabs.Root>
+    </div>
+  );
+}

--- a/apps/astro/src/components/TabsDemo.tsx
+++ b/apps/astro/src/components/TabsDemo.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { Tabs } from "@repo/ds";
+
+const ITEMS = [
+  { value: "account", label: "Account", body: "Make changes to your account." },
+  {
+    value: "documents",
+    label: "Documents",
+    body: "Access and update your documents.",
+  },
+  {
+    value: "settings",
+    label: "Settings",
+    body: "Edit your profile or update contact information.",
+  },
+];
+
+// Uncontrolled Tabs demo. `id` gives deterministic ids for tests (omit it to
+// exercise the useId-derived base). The last onValueChange value is rendered
+// so tests can assert notifications.
+export default function TabsDemo({
+  id,
+  defaultValue = "account",
+  orientation,
+}: {
+  id?: string;
+  defaultValue?: string;
+  orientation?: "horizontal" | "vertical";
+}) {
+  const [last, setLast] = useState("");
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  return (
+    <div
+      data-testid={id ? `demo-${id}` : "demo"}
+      data-hydrated={hydrated ? "true" : "false"}
+    >
+      <Tabs.Root
+        id={id}
+        defaultValue={defaultValue}
+        orientation={orientation}
+        onValueChange={setLast}
+      >
+        <Tabs.List>
+          {ITEMS.map((item) => (
+            <Tabs.Trigger key={item.value} id={id} value={item.value}>
+              {item.label}
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
+        <div>
+          {ITEMS.map((item) => (
+            <Tabs.Content key={item.value} id={id} value={item.value}>
+              {item.body}
+            </Tabs.Content>
+          ))}
+        </div>
+      </Tabs.Root>
+      <p data-testid={id ? `last-${id}` : "last"}>{last}</p>
+    </div>
+  );
+}

--- a/apps/astro/src/pages/test/composition.astro
+++ b/apps/astro/src/pages/test/composition.astro
@@ -1,0 +1,13 @@
+---
+import MultiDemo from "../../components/MultiDemo.tsx";
+---
+
+<html lang="en">
+  <body>
+    <!-- Two instances in one React tree, no explicit ids: useId disambiguates. -->
+    <MultiDemo client:load />
+    <script>
+      import "@repo/ds/tabs/define";
+    </script>
+  </body>
+</html>

--- a/apps/astro/src/pages/test/controlled.astro
+++ b/apps/astro/src/pages/test/controlled.astro
@@ -1,0 +1,13 @@
+---
+import ControlledTabs from "../../components/ControlledTabs.tsx";
+---
+
+<html lang="en">
+  <body>
+    <ControlledTabs client:load id="cv" preHydration="ignore" />
+    <ControlledTabs client:load id="cs" preHydration="report" />
+    <script>
+      import "@repo/ds/tabs/define";
+    </script>
+  </body>
+</html>

--- a/apps/astro/src/pages/test/hydrated.astro
+++ b/apps/astro/src/pages/test/hydrated.astro
@@ -1,0 +1,14 @@
+---
+import TabsDemo from "../../components/TabsDemo.tsx";
+---
+
+<html lang="en">
+  <body>
+    <!-- Hydrated islands with explicit, distinct ids (independent). One vertical. -->
+    <TabsDemo client:load id="h" />
+    <TabsDemo client:load id="v" orientation="vertical" />
+    <script>
+      import "@repo/ds/tabs/define";
+    </script>
+  </body>
+</html>

--- a/apps/astro/src/pages/test/tabs-nested.astro
+++ b/apps/astro/src/pages/test/tabs-nested.astro
@@ -1,0 +1,12 @@
+---
+import NestedTabsDemo from "../../components/NestedTabsDemo.tsx";
+---
+
+<html lang="en">
+  <body>
+    <NestedTabsDemo client:load />
+    <script>
+      import "@repo/ds/tabs/define";
+    </script>
+  </body>
+</html>

--- a/apps/astro/src/pages/test/upgraded.astro
+++ b/apps/astro/src/pages/test/upgraded.astro
@@ -1,0 +1,14 @@
+---
+import TabsDemo from "../../components/TabsDemo.tsx";
+---
+
+<html lang="en">
+  <body>
+    <!-- No client directive: SSR markup that the define script upgrades to a
+         tablist, but React never hydrates. -->
+    <TabsDemo id="up" />
+    <script>
+      import "@repo/ds/tabs/define";
+    </script>
+  </body>
+</html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,25 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.61.1
+      istanbul-lib-coverage:
+        specifier: ^3.2.2
+        version: 3.2.2
+      istanbul-lib-report:
+        specifier: ^3.0.1
+        version: 3.0.1
+      istanbul-reports:
+        specifier: ^3.2.0
+        version: 3.2.0
+      playwright:
+        specifier: ^1.59.1
+        version: 1.61.1
+      v8-to-istanbul:
+        specifier: ^9.3.0
+        version: 9.3.0
 
   apps/vite:
     dependencies:
@@ -133,7 +152,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
     dev: false
 
   /@astrojs/compiler@4.0.0:
@@ -306,7 +325,7 @@ packages:
       '@babel/parser': 7.27.0
       '@babel/types': 7.27.0
       '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
     dev: false
 
@@ -1620,7 +1639,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.31
     dev: false
 
   /@jridgewell/remapping@2.3.5:
@@ -1643,20 +1662,12 @@ packages:
 
   /@jridgewell/sourcemap-codec@1.5.5:
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-    dev: false
-
-  /@jridgewell/trace-mapping@0.3.25:
-    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
-    dev: false
 
   /@jridgewell/trace-mapping@0.3.31:
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1679,6 +1690,14 @@ packages:
   /@oslojs/encoding@1.1.0:
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
     dev: false
+
+  /@playwright/test@1.61.1:
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright: 1.61.1
+    dev: true
 
   /@rolldown/pluginutils@1.0.0-rc.3:
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
@@ -2163,6 +2182,10 @@ packages:
     dependencies:
       '@types/unist': 3.0.3
     dev: false
+
+  /@types/istanbul-lib-coverage@2.0.6:
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+    dev: true
 
   /@types/mdast@4.0.4:
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -3168,6 +3191,14 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  /fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3374,6 +3405,10 @@ packages:
       hermes-estree: 0.25.1
     dev: false
 
+  /html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    dev: true
+
   /html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
     dev: false
@@ -3468,6 +3503,28 @@ packages:
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  /istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+    dev: true
+
+  /istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+    dev: true
+
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3554,6 +3611,13 @@ packages:
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
     dev: false
+
+  /make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+    dependencies:
+      semver: 7.8.5
+    dev: true
 
   /markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -4179,6 +4243,22 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dev: true
+
+  /playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4489,7 +4569,6 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: false
 
   /sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -4918,6 +4997,15 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.1
+
+  /v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
+    dev: true
 
   /vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}


### PR DESCRIPTION
Adds the Astro Playwright e2e suite for the Tabs component: no-JS radio fallback, `<ds-tabs>` upgrade, and hydrated / controlled / composition / nested / pre-hydration specs, with V8 coverage reporting and the PR CI workflow.

Rebased onto `main` (the Tabs component + Astro app from #3 are merged).