### PR TITLE
test: Vite Playwright e2e + V8 coverage for Tabs (CSR)

### DIFF
--- a/apps/vite/.gitignore
+++ b/apps/vite/.gitignore
@@ -1,0 +1,8 @@
+# build output
+dist/
+
+# playwright + coverage
+test-results/
+playwright-report/
+coverage/
+e2e/.v8/

--- a/apps/vite/e2e/generate-reports.mjs
+++ b/apps/vite/e2e/generate-reports.mjs
@@ -1,0 +1,62 @@
+import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import libCoverage from "istanbul-lib-coverage";
+import libReport from "istanbul-lib-report";
+import reports from "istanbul-reports";
+import v8toIstanbul from "v8-to-istanbul";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appDir = resolve(here, "..");
+const repoRoot = resolve(appDir, "..", "..");
+const distDir = resolve(appDir, "dist");
+const v8Dir = resolve(here, ".v8");
+const outDir = resolve(appDir, "coverage", "e2e");
+
+const keep = (file) => {
+  const norm = file.replaceAll("\\", "/");
+  return (
+    norm.endsWith("packages/ds/components/tabs.tsx") ||
+    norm.endsWith("packages/ds/components/ds-tabs.ts")
+  );
+};
+
+async function main() {
+  if (!existsSync(v8Dir)) {
+    console.error("No coverage collected - run `pnpm test:e2e:coverage`.");
+    process.exit(1);
+  }
+
+  const map = libCoverage.createCoverageMap({});
+
+  for (const name of readdirSync(v8Dir).filter((n) => n.endsWith(".json"))) {
+    const entries = JSON.parse(readFileSync(resolve(v8Dir, name), "utf8"));
+    for (const entry of entries) {
+      const { pathname } = new URL(entry.url);
+      const filePath = resolve(distDir, `.${pathname}`);
+      if (!existsSync(filePath)) continue;
+
+      const converter = v8toIstanbul(filePath, 0, { source: entry.source });
+      await converter.load();
+      converter.applyCoverage(entry.functions);
+
+      for (const [file, fileCov] of Object.entries(converter.toIstanbul())) {
+        if (keep(file)) map.addFileCoverage(fileCov);
+      }
+    }
+  }
+
+  const context = libReport.createContext({ dir: outDir, coverageMap: map });
+  reports.create("text-summary").execute(context);
+  reports.create("html").execute(context);
+  reports.create("lcovonly").execute(context);
+  reports.create("json-summary").execute(context);
+
+  rmSync(v8Dir, { recursive: true, force: true });
+  console.log(`\nCoverage report written to ${relative(repoRoot, outDir)}/`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/vite/e2e/helpers/fixture.ts
+++ b/apps/vite/e2e/helpers/fixture.ts
@@ -1,0 +1,36 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test as base, expect } from "@playwright/test";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const V8_DIR = resolve(here, "..", ".v8");
+
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    if (process.env.E2E_COVERAGE !== "true") {
+      await use(page);
+      return;
+    }
+    await page.coverage.startJSCoverage({ resetOnNavigation: false });
+    await use(page);
+    const entries = await page.coverage.stopJSCoverage();
+    const appEntries = entries.filter((entry) => {
+      const { pathname } = new URL(entry.url);
+      return (
+        pathname.startsWith("/assets/") && !pathname.includes("node_modules")
+      );
+    });
+    if (appEntries.length > 0) {
+      mkdirSync(V8_DIR, { recursive: true });
+      writeFileSync(
+        resolve(V8_DIR, `${randomUUID()}.json`),
+        JSON.stringify(appEntries),
+      );
+    }
+  },
+});
+
+export { expect };
+export type { Page } from "@playwright/test";

--- a/apps/vite/e2e/tests/tabs/controlled.spec.ts
+++ b/apps/vite/e2e/tests/tabs/controlled.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "../../helpers/fixture";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.locator('[data-testid="controlled"] [role="tablist"]'),
+  ).toBeVisible();
+});
+
+const tabs = (page: import("../../helpers/fixture").Page) =>
+  page.locator('[data-testid="controlled"]');
+
+test("the active tab reflects the controlled value", async ({ page }) => {
+  await expect(
+    tabs(page).getByRole("tab", { name: "Account" }),
+  ).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator('[data-testid="value"]')).toHaveText("account");
+});
+
+test("an external (programmatic) value change drives the tab, no echo", async ({
+  page,
+}) => {
+  await page.locator('[data-testid="ext"]').click();
+  await expect(
+    tabs(page).getByRole("tab", { name: "Settings" }),
+  ).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator('[data-testid="value"]')).toHaveText("settings");
+  await expect(page.locator('[data-testid="changes"]')).toHaveText("0");
+});
+
+test("a user click is reported through onValueChange", async ({ page }) => {
+  await tabs(page).getByRole("tab", { name: "Documents" }).click();
+  await expect(page.locator('[data-testid="value"]')).toHaveText("documents");
+  await expect(page.locator('[data-testid="changes"]')).toHaveText("1");
+  await expect(
+    tabs(page).getByRole("tab", { name: "Documents" }),
+  ).toHaveAttribute("aria-selected", "true");
+});

--- a/apps/vite/e2e/tests/tabs/csr.spec.ts
+++ b/apps/vite/e2e/tests/tabs/csr.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "../../helpers/fixture";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.locator('[data-testid="uncontrolled"] [role="tablist"]'),
+  ).toBeVisible();
+});
+
+test("upgrades to a tablist with no define script", async ({ page }) => {
+  await expect(page.locator("ds-tabs").first()).toBeVisible();
+  const d = page.locator('[data-testid="uncontrolled"]');
+  await expect(d.getByRole("tab")).toHaveCount(3);
+  await expect(d.getByRole("tabpanel")).toHaveCount(1);
+  await expect(d.getByRole("tab", { name: "Account" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+});
+
+test("roving tabindex: active tab is 0, the rest -1", async ({ page }) => {
+  const d = page.locator('[data-testid="uncontrolled"]');
+  await expect(d.getByRole("tab", { name: "Account" })).toHaveAttribute(
+    "tabindex",
+    "0",
+  );
+  await expect(d.getByRole("tab", { name: "Documents" })).toHaveAttribute(
+    "tabindex",
+    "-1",
+  );
+});
+
+test("arrow keys move on-axis; Home/End jump; off-axis ignored", async ({
+  page,
+}) => {
+  const d = page.locator('[data-testid="uncontrolled"]');
+  await d.getByRole("tab", { name: "Account" }).focus();
+  await page.keyboard.press("ArrowRight");
+  await expect(d.getByRole("tab", { name: "Documents" })).toBeFocused();
+  await page.keyboard.press("ArrowDown");
+  await expect(d.getByRole("tab", { name: "Documents" })).toBeFocused();
+  await page.keyboard.press("End");
+  await expect(d.getByRole("tab", { name: "Settings" })).toBeFocused();
+  await page.keyboard.press("Home");
+  await expect(d.getByRole("tab", { name: "Account" })).toBeFocused();
+});
+
+test("onValueChange fires on a user change, not on mount", async ({ page }) => {
+  await expect(page.locator('[data-testid="last"]')).toHaveText("");
+  await page
+    .locator('[data-testid="uncontrolled"]')
+    .getByRole("tab", { name: "Documents" })
+    .click();
+  await expect(page.locator('[data-testid="last"]')).toHaveText("documents");
+});

--- a/apps/vite/package.json
+++ b/apps/vite/package.json
@@ -7,7 +7,9 @@
     "dev": "vite --clearScreen false",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint \"src/**/*.{ts,tsx}\""
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "test:e2e": "playwright test",
+    "test:e2e:coverage": "E2E_COVERAGE=true playwright test; node e2e/generate-reports.mjs"
   },
   "dependencies": {
     "@repo/ds": "workspace:*",
@@ -15,13 +17,19 @@
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^5.2.0",
     "eslint": "^8.57.0",
+    "istanbul-lib-coverage": "^3.2.2",
+    "istanbul-lib-report": "^3.0.1",
+    "istanbul-reports": "^3.2.0",
+    "playwright": "^1.59.1",
     "typescript": "5.5.4",
+    "v8-to-istanbul": "^9.3.0",
     "vite": "^5.1.4"
   }
 }

--- a/apps/vite/playwright.config.ts
+++ b/apps/vite/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e/tests",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: "http://localhost:4173",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "pnpm build && pnpm preview",
+    url: "http://localhost:4173",
+    reuseExistingServer: false,
+    timeout: 120_000,
+    gracefulShutdown: { signal: "SIGTERM", timeout: 10_000 },
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/apps/vite/src/main.tsx
+++ b/apps/vite/src/main.tsx
@@ -3,41 +3,57 @@ import { createRoot } from "react-dom/client";
 import "@repo/ds/style.css";
 import { Tabs } from "@repo/ds";
 
-const Uncontrolled = () => (
-  <Tabs.Root
-    defaultValue="account"
-    onValueChange={(value: string) => console.log(value)}
-  >
-    <Tabs.List>
-      <Tabs.Trigger value="account">Account</Tabs.Trigger>
-      <Tabs.Trigger value="documents">Documents</Tabs.Trigger>
-      <Tabs.Trigger value="settings">Settings</Tabs.Trigger>
-    </Tabs.List>
+const Uncontrolled = () => {
+  const [last, setLast] = useState("");
+  return (
+    <div data-testid="uncontrolled">
+      <Tabs.Root defaultValue="account" onValueChange={setLast}>
+        <Tabs.List>
+          <Tabs.Trigger value="account">Account</Tabs.Trigger>
+          <Tabs.Trigger value="documents">Documents</Tabs.Trigger>
+          <Tabs.Trigger value="settings">Settings</Tabs.Trigger>
+        </Tabs.List>
 
-    <div>
-      <Tabs.Content value="account">Make changes to your account.</Tabs.Content>
-      <Tabs.Content value="documents">
-        Access and update your documents.
-      </Tabs.Content>
-      <Tabs.Content value="settings">
-        Edit your profile or update contact information.
-      </Tabs.Content>
+        <div>
+          <Tabs.Content value="account">
+            Make changes to your account.
+          </Tabs.Content>
+          <Tabs.Content value="documents">
+            Access and update your documents.
+          </Tabs.Content>
+          <Tabs.Content value="settings">
+            Edit your profile or update contact information.
+          </Tabs.Content>
+        </div>
+      </Tabs.Root>
+      <p data-testid="last">{last}</p>
     </div>
-  </Tabs.Root>
-);
+  );
+};
 
 const Controlled = () => {
   const [value, setValue] = useState("account");
+  const [changes, setChanges] = useState(0);
   return (
-    <div>
+    <div data-testid="controlled">
       <p>
-        Selected: <strong>{value}</strong>{" "}
-        {/* Drives the tab from outside the component to show it is controlled. */}
-        <button type="button" onClick={() => setValue("settings")}>
+        Selected: <strong data-testid="value">{value}</strong>{" "}
+        <span data-testid="changes">{changes}</span>{" "}
+        <button
+          type="button"
+          data-testid="ext"
+          onClick={() => setValue("settings")}
+        >
           Jump to Settings
         </button>
       </p>
-      <Tabs.Root value={value} onValueChange={setValue}>
+      <Tabs.Root
+        value={value}
+        onValueChange={(next) => {
+          setValue(next);
+          setChanges((count) => count + 1);
+        }}
+      >
         <Tabs.List>
           <Tabs.Trigger value="account">Account</Tabs.Trigger>
           <Tabs.Trigger value="documents">Documents</Tabs.Trigger>

--- a/apps/vite/vite.config.ts
+++ b/apps/vite/vite.config.ts
@@ -3,4 +3,10 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    sourcemap: true,
+    // Unminified under coverage so V8->Istanbul recovers branch/function data.
+    minify: process.env.E2E_COVERAGE === "true" ? false : "esbuild",
+  },
 });
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
         specifier: ^19.2.0
         version: 19.2.7(react@19.2.7)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.61.1
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
@@ -91,9 +94,24 @@ importers:
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
+      istanbul-lib-coverage:
+        specifier: ^3.2.2
+        version: 3.2.2
+      istanbul-lib-report:
+        specifier: ^3.0.1
+        version: 3.0.1
+      istanbul-reports:
+        specifier: ^3.2.0
+        version: 3.2.0
+      playwright:
+        specifier: ^1.59.1
+        version: 1.61.1
       typescript:
         specifier: 5.5.4
         version: 5.5.4
+      v8-to-istanbul:
+        specifier: ^9.3.0
+        version: 9.3.0
       vite:
         specifier: ^5.1.4
         version: 5.4.17


### PR DESCRIPTION
Adds the Vite (client-side-rendered) Playwright e2e suite for the Tabs component: CSR and controlled specs, V8 coverage reporting, and the demo section in `main.tsx`.
