### PR TITLE
chore: gitignore .claude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist-ssr
 .cache
 server/dist
 public/dist
+.claude


### PR DESCRIPTION
Ignore the `.claude/` directory (local Claude Code worktrees, settings, task state) so it can't be accidentally staged - e.g. when working across multiple sessions/worktrees.