### PR TITLE
ci: fix vite.config.ts formatting to unblock main

### DIFF
--- a/apps/vite/vite.config.ts
+++ b/apps/vite/vite.config.ts
@@ -9,4 +9,3 @@ export default defineConfig({
     minify: process.env.E2E_COVERAGE === "true" ? false : "esbuild",
   },
 });
-


### PR DESCRIPTION
`main` is red on the new `format` check: #7 added `apps/vite/vite.config.ts` with a trailing blank line and merged alongside #10 (which introduced the prettier gate). Each PR passed alone; combined on `main` the format check fails — the "green alone, broken combined" case a merge queue would have caught.

One-line fix: remove the trailing blank line.

Verified locally: `format:check`, `lint`, `build` all pass.