### PR TITLE
test: hydration-warning check (dev React) + merged coverage report

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,12 +28,20 @@ jobs:
       - name: Install Playwright browser
         run: pnpm --filter astro exec playwright install --with-deps chromium
 
-      - name: Run Tabs e2e tests
+      - name: Astro Tabs e2e (production)
         run: pnpm --filter astro test:e2e
+
+      - name: Astro hydration-warning check (dev React)
+        run: pnpm --filter astro test:e2e:hydration
+
+      - name: Vite Tabs e2e (CSR)
+        run: pnpm --filter vite test:e2e
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
-          path: apps/astro/playwright-report
+          path: |
+            apps/astro/playwright-report
+            apps/vite/playwright-report
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist-ssr
 .cache
 server/dist
 public/dist
+coverage

--- a/apps/astro/astro.config.mjs
+++ b/apps/astro/astro.config.mjs
@@ -3,10 +3,20 @@ import { defineConfig } from "astro/config";
 
 import react from "@astrojs/react";
 
+// When E2E_DEV_REACT is set, bundle React's development build into the static
+// output (no dev server, no Astro toolbar) so hydration warnings still fire and
+// the console-assertion test can catch them.
+const devReact = process.env.E2E_DEV_REACT === "true";
+
 // https://astro.build/config
 export default defineConfig({
   integrations: [react()],
-  // Emit source maps so Playwright V8 coverage maps the built _astro chunks
-  // back to the @repo/ds TypeScript sources.
-  vite: { build: { sourcemap: true } },
+  vite: {
+    // Emit source maps so Playwright V8 coverage maps the built _astro chunks
+    // back to the @repo/ds TypeScript sources.
+    build: { sourcemap: true, minify: devReact ? false : "esbuild" },
+    ...(devReact
+      ? { define: { "process.env.NODE_ENV": '"development"' } }
+      : {}),
+  },
 });

--- a/apps/astro/e2e/generate-reports.mjs
+++ b/apps/astro/e2e/generate-reports.mjs
@@ -59,6 +59,7 @@ async function main() {
   reports.create("html").execute(context);
   reports.create("lcovonly").execute(context);
   reports.create("json-summary").execute(context);
+  reports.create("json").execute(context); // coverage-final.json, for merging
 
   rmSync(v8Dir, { recursive: true, force: true });
   console.log(`\nCoverage report written to ${relative(repoRoot, outDir)}/`);

--- a/apps/astro/e2e/tests/tabs/hydrated.spec.ts
+++ b/apps/astro/e2e/tests/tabs/hydrated.spec.ts
@@ -50,7 +50,10 @@ test("instances are independent", async ({ page }) => {
   ).toHaveAttribute("aria-selected", "true");
 });
 
-test("logs no hydration warnings or errors", async ({ page }) => {
+// Production smoke check for runtime/thrown errors. React's hydration
+// mismatch warnings are dev-only (stripped here), so they're caught instead by
+// hydration-warnings.spec.ts, which runs against a dev-React build.
+test("logs no console errors (production)", async ({ page }) => {
   const errors: string[] = [];
   page.on("console", (m) => {
     if (m.type() === "error") errors.push(m.text());

--- a/apps/astro/e2e/tests/tabs/hydration-warnings.spec.ts
+++ b/apps/astro/e2e/tests/tabs/hydration-warnings.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "../../helpers/fixture";
+
+const pages = ["/test/hydrated", "/test/controlled", "/test/composition"];
+
+for (const path of pages) {
+  test(`no hydration warnings or errors on ${path}`, async ({ page }) => {
+    const errors: string[] = [];
+    page.on("console", (m) => {
+      if (m.type() === "error") errors.push(m.text());
+    });
+    page.on("pageerror", (e) => errors.push(String(e)));
+
+    await page.goto(path);
+    await expect(page.locator('[data-hydrated="true"]').first()).toBeVisible();
+    await page.locator('[role="tab"]').first().click();
+
+    expect(errors).toEqual([]);
+  });
+}

--- a/apps/astro/package.json
+++ b/apps/astro/package.json
@@ -8,7 +8,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "test:e2e": "playwright test",
-    "test:e2e:coverage": "E2E_COVERAGE=true playwright test; node e2e/generate-reports.mjs"
+    "test:e2e:coverage": "E2E_COVERAGE=true playwright test; node e2e/generate-reports.mjs",
+    "test:e2e:hydration": "playwright test --config playwright.hydration.config.ts"
   },
   "dependencies": {
     "@astrojs/react": "^5.0.7",

--- a/apps/astro/playwright.config.ts
+++ b/apps/astro/playwright.config.ts
@@ -7,6 +7,9 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e/tests",
+  // The hydration-warning spec needs a dev-React build; it runs via
+  // playwright.hydration.config.ts, not this production run.
+  testIgnore: "**/hydration-warnings.spec.ts",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,

--- a/apps/astro/playwright.hydration.config.ts
+++ b/apps/astro/playwright.hydration.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Builds with dev React (E2E_DEV_REACT) so hydration mismatches actually throw.
+export default defineConfig({
+  testDir: "./e2e/tests",
+  testMatch: "**/hydration-warnings.spec.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [["list"]],
+  use: {
+    baseURL: "http://localhost:4321",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "E2E_DEV_REACT=true pnpm build && pnpm preview",
+    url: "http://localhost:4321",
+    reuseExistingServer: false,
+    timeout: 120_000,
+    gracefulShutdown: { signal: "SIGTERM", timeout: 10_000 },
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/apps/vite/e2e/generate-reports.mjs
+++ b/apps/vite/e2e/generate-reports.mjs
@@ -51,6 +51,7 @@ async function main() {
   reports.create("html").execute(context);
   reports.create("lcovonly").execute(context);
   reports.create("json-summary").execute(context);
+  reports.create("json").execute(context); // coverage-final.json, for merging
 
   rmSync(v8Dir, { recursive: true, force: true });
   console.log(`\nCoverage report written to ${relative(repoRoot, outDir)}/`);

--- a/package.json
+++ b/package.json
@@ -5,10 +5,15 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "format:check": "prettier --check \"**/*.{ts,tsx,md}\""
+    "format:check": "prettier --check \"**/*.{ts,tsx,md}\"",
+    "coverage": "pnpm --filter astro test:e2e:coverage && pnpm --filter vite test:e2e:coverage && pnpm coverage:merge",
+    "coverage:merge": "node scripts/merge-coverage.mjs"
   },
   "devDependencies": {
     "eslint": "^8.57.0",
+    "istanbul-lib-coverage": "^3.2.2",
+    "istanbul-lib-report": "^3.0.1",
+    "istanbul-reports": "^3.2.0",
     "prettier": "^3.2.5",
     "turbo": "^2.5.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
+      istanbul-lib-coverage:
+        specifier: ^3.2.2
+        version: 3.2.2
+      istanbul-lib-report:
+        specifier: ^3.0.1
+        version: 3.0.1
+      istanbul-reports:
+        specifier: ^3.2.0
+        version: 3.2.0
       prettier:
         specifier: ^3.2.5
         version: 3.5.3

--- a/scripts/merge-coverage.mjs
+++ b/scripts/merge-coverage.mjs
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import libCoverage from "istanbul-lib-coverage";
+import libReport from "istanbul-lib-report";
+import reports from "istanbul-reports";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..");
+const sources = [
+  resolve(repoRoot, "apps/astro/coverage/e2e/coverage-final.json"),
+  resolve(repoRoot, "apps/vite/coverage/e2e/coverage-final.json"),
+];
+const outDir = resolve(repoRoot, "coverage/merged");
+
+const map = libCoverage.createCoverageMap({});
+let found = 0;
+for (const file of sources) {
+  if (!existsSync(file)) {
+    console.warn(`skip (missing): ${relative(repoRoot, file)}`);
+    continue;
+  }
+  found += 1;
+  map.merge(JSON.parse(readFileSync(file, "utf8")));
+}
+
+if (found === 0) {
+  console.error(
+    "No per-app coverage found. Run `pnpm coverage` (or each app's test:e2e:coverage) first.",
+  );
+  process.exit(1);
+}
+
+const context = libReport.createContext({ dir: outDir, coverageMap: map });
+reports.create("text-summary").execute(context);
+reports.create("html").execute(context);
+reports.create("lcovonly").execute(context);
+reports.create("json-summary").execute(context);
+console.log(`\nMerged coverage (${found} sources) -> ${relative(repoRoot, outDir)}/`);


### PR DESCRIPTION
Two e2e-tooling additions that the component PRs build on:

- **Hydration-warning check** - a separate Playwright config (`playwright.hydration.config.ts`) that builds Astro with React's *development* build (`E2E_DEV_REACT`) so hydration mismatches surface as console errors. `hydration-warnings.spec.ts` fails if any of the hydrated Tabs pages logs a warning, guarding the per-part `suppressHydrationWarning` usage. CI now runs the Astro production suite, this hydration suite, and the Vite CSR suite.
- **Merged coverage** - `scripts/merge-coverage.mjs` + a `pnpm coverage` script combine the per-app V8/Istanbul coverage (Astro SSR/hydrated + Vite CSR) into one report at `coverage/merged/`.

Prerequisite for the Modal / Popover / Radio Cards / Accordion PRs, which register their `/test/*` pages and coverage entries here.