### PR TITLE
ds: Modal - native <dialog popover>, no-JS compound API

### DIFF
--- a/apps/astro/e2e/generate-reports.mjs
+++ b/apps/astro/e2e/generate-reports.mjs
@@ -25,7 +25,8 @@ const keep = (file) => {
   const norm = file.replaceAll("\\", "/");
   return (
     norm.endsWith("packages/ds/components/tabs.tsx") ||
-    norm.endsWith("packages/ds/components/ds-tabs.ts")
+    norm.endsWith("packages/ds/components/ds-tabs.ts") ||
+    norm.endsWith("packages/ds/components/modal.tsx")
   );
 };
 

--- a/apps/astro/e2e/tests/hydration-warnings.spec.ts
+++ b/apps/astro/e2e/tests/hydration-warnings.spec.ts
@@ -1,6 +1,11 @@
-import { test, expect } from "../../helpers/fixture";
+import { test, expect } from "../helpers/fixture";
 
-const pages = ["/test/hydrated", "/test/controlled", "/test/composition"];
+const pages = [
+  "/test/hydrated",
+  "/test/controlled",
+  "/test/composition",
+  "/test/modal",
+];
 
 for (const path of pages) {
   test(`no hydration warnings or errors on ${path}`, async ({ page }) => {
@@ -12,7 +17,7 @@ for (const path of pages) {
 
     await page.goto(path);
     await expect(page.locator('[data-hydrated="true"]').first()).toBeVisible();
-    await page.locator('[role="tab"]').first().click();
+    await page.locator('[role="tab"], button').first().click();
 
     expect(errors).toEqual([]);
   });

--- a/apps/astro/e2e/tests/modal/modal.spec.ts
+++ b/apps/astro/e2e/tests/modal/modal.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "../../helpers/fixture";
+
+test.describe("native popover modal", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/test/modal");
+  });
+
+  test("trigger opens the dialog (un-hydrated SSR instance)", async ({
+    page,
+  }) => {
+    await expect(page.locator("#ssr")).toBeHidden();
+    await page.locator('[data-testid="ssr-open"]').click();
+    await expect(page.locator("#ssr")).toBeVisible();
+  });
+
+  test("the X and Done buttons close it", async ({ page }) => {
+    const dialog = page.locator("#ssr");
+    await page.locator('[data-testid="ssr-open"]').click();
+    await expect(dialog).toBeVisible();
+    await page.locator('[data-testid="ssr-x"]').click();
+    await expect(dialog).toBeHidden();
+
+    await page.locator('[data-testid="ssr-open"]').click();
+    await expect(dialog).toBeVisible();
+    await page.locator('[data-testid="ssr-done"]').click();
+    await expect(dialog).toBeHidden();
+  });
+
+  test("Escape closes it (native)", async ({ page }) => {
+    await page.locator('[data-testid="ssr-open"]').click();
+    await expect(page.locator("#ssr")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.locator("#ssr")).toBeHidden();
+  });
+
+  test("outside click light-dismisses it (native)", async ({ page }) => {
+    await page.locator('[data-testid="ssr-open"]').click();
+    await expect(page.locator("#ssr")).toBeVisible();
+    await page.mouse.click(3, 3); // top-left corner, outside the centered dialog
+    await expect(page.locator("#ssr")).toBeHidden();
+  });
+
+  test("has an accessible name and a labelled close button", async ({
+    page,
+  }) => {
+    const dialog = page.locator("#ssr");
+    await expect(dialog).toHaveAttribute("aria-labelledby", "ssr-title");
+    await expect(page.locator("#ssr-title")).toHaveText("Account settings");
+    await expect(page.locator('[data-testid="ssr-x"]')).toHaveAttribute(
+      "aria-label",
+      "Close",
+    );
+  });
+
+  test("the hydrated instance also opens and closes", async ({ page }) => {
+    await expect(page.locator('[data-testid="modal-hyd"]')).toHaveAttribute(
+      "data-hydrated",
+      "true",
+    );
+    await page.locator('[data-testid="hyd-open"]').click();
+    await expect(page.locator("#hyd")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.locator("#hyd")).toBeHidden();
+  });
+});
+
+test.describe("without JavaScript", () => {
+  test.use({ javaScriptEnabled: false });
+
+  test("the trigger still opens the dialog", async ({ page }) => {
+    await page.goto("/test/modal");
+    await expect(page.locator("#ssr")).toBeHidden();
+    await page.locator('[data-testid="ssr-open"]').click();
+    await expect(page.locator("#ssr")).toBeVisible();
+  });
+});

--- a/apps/astro/e2e/tests/modal/nested.spec.ts
+++ b/apps/astro/e2e/tests/modal/nested.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "../../helpers/fixture";
+
+test.describe("nested native popover modals", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/test/modal-nested");
+  });
+
+  const outer = (page: import("../../helpers/fixture").Page) =>
+    page.locator("#ssr-outer");
+  const inner = (page: import("../../helpers/fixture").Page) =>
+    page.locator("#ssr-inner");
+
+  test("opening the inner modal keeps the outer one open", async ({ page }) => {
+    await page.locator('[data-testid="ssr-outer-open"]').click();
+    await expect(outer(page)).toBeVisible();
+    await page.locator('[data-testid="ssr-inner-open"]').click();
+    await expect(inner(page)).toBeVisible();
+    await expect(outer(page)).toBeVisible();
+  });
+
+  test("closing the inner modal leaves the outer open", async ({ page }) => {
+    await page.locator('[data-testid="ssr-outer-open"]').click();
+    await page.locator('[data-testid="ssr-inner-open"]').click();
+    await expect(inner(page)).toBeVisible();
+    await page.locator('[data-testid="ssr-inner-done"]').click();
+    await expect(inner(page)).toBeHidden();
+    await expect(outer(page)).toBeVisible();
+  });
+
+  test("Escape closes the top-most (inner) first, then the outer", async ({
+    page,
+  }) => {
+    await page.locator('[data-testid="ssr-outer-open"]').click();
+    await page.locator('[data-testid="ssr-inner-open"]').click();
+    await expect(inner(page)).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(inner(page)).toBeHidden();
+    await expect(outer(page)).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(outer(page)).toBeHidden();
+  });
+});
+
+test.describe("without JavaScript", () => {
+  test.use({ javaScriptEnabled: false });
+
+  test("nested modals open without JS", async ({ page }) => {
+    await page.goto("/test/modal-nested");
+    await page.locator('[data-testid="ssr-outer-open"]').click();
+    await expect(page.locator("#ssr-outer")).toBeVisible();
+    await page.locator('[data-testid="ssr-inner-open"]').click();
+    await expect(page.locator("#ssr-inner")).toBeVisible();
+    await expect(page.locator("#ssr-outer")).toBeVisible();
+  });
+});

--- a/apps/astro/src/components/ModalDemo.tsx
+++ b/apps/astro/src/components/ModalDemo.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { Modal } from "@repo/ds";
+
+export default function ModalDemo({ id }: { id?: string }) {
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  return (
+    <div
+      data-testid={id ? `modal-${id}` : "modal"}
+      data-hydrated={hydrated ? "true" : "false"}
+    >
+      <Modal.Root id={id}>
+        <Modal.Trigger data-testid={id ? `${id}-open` : "open"}>
+          Open
+        </Modal.Trigger>
+        <Modal.Content>
+          <Modal.Title>Account settings</Modal.Title>
+          <Modal.Description>
+            Make changes to your account here.
+          </Modal.Description>
+          <div style={{ padding: "0 16px 16px" }}>
+            <Modal.Close aria-label="Close" data-testid={id ? `${id}-x` : "x"}>
+              X
+            </Modal.Close>{" "}
+            <Modal.Close data-testid={id ? `${id}-done` : "done"}>
+              Done
+            </Modal.Close>
+          </div>
+        </Modal.Content>
+      </Modal.Root>
+    </div>
+  );
+}

--- a/apps/astro/src/components/NestedModalDemo.tsx
+++ b/apps/astro/src/components/NestedModalDemo.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { Modal } from "@repo/ds";
+
+export default function NestedModalDemo({ id }: { id: string }) {
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  return (
+    <div
+      data-testid={`nmodal-${id}`}
+      data-hydrated={hydrated ? "true" : "false"}
+    >
+      <Modal.Root id={`${id}-outer`}>
+        <Modal.Trigger data-testid={`${id}-outer-open`}>
+          Open outer
+        </Modal.Trigger>
+        <Modal.Content>
+          <Modal.Title>Outer</Modal.Title>
+          <div style={{ padding: "0 16px 16px" }}>
+            <Modal.Root id={`${id}-inner`}>
+              <Modal.Trigger data-testid={`${id}-inner-open`}>
+                Open inner
+              </Modal.Trigger>
+              <Modal.Content>
+                <Modal.Title>Inner</Modal.Title>
+                <div style={{ padding: "0 16px 16px" }}>
+                  <Modal.Close data-testid={`${id}-inner-done`}>
+                    Close inner
+                  </Modal.Close>
+                </div>
+              </Modal.Content>
+            </Modal.Root>
+            <Modal.Close data-testid={`${id}-outer-done`}>
+              Close outer
+            </Modal.Close>
+          </div>
+        </Modal.Content>
+      </Modal.Root>
+    </div>
+  );
+}

--- a/apps/astro/src/pages/test/modal-nested.astro
+++ b/apps/astro/src/pages/test/modal-nested.astro
@@ -1,0 +1,13 @@
+---
+import NestedModalDemo from "../../components/NestedModalDemo.tsx";
+---
+
+<html lang="en">
+  <body>
+    <!-- Un-hydrated SSR: nested native popovers work with no JS. -->
+    <NestedModalDemo id="ssr" />
+
+    <!-- Hydrated island: identical markup. -->
+    <NestedModalDemo client:load id="hyd" />
+  </body>
+</html>

--- a/apps/astro/src/pages/test/modal.astro
+++ b/apps/astro/src/pages/test/modal.astro
@@ -1,0 +1,13 @@
+---
+import ModalDemo from "../../components/ModalDemo.tsx";
+---
+
+<html lang="en">
+  <body>
+    <!-- Un-hydrated SSR: the native popover opens/closes with no JS at all. -->
+    <ModalDemo id="ssr" />
+
+    <!-- Hydrated island: identical markup, also works. -->
+    <ModalDemo client:load id="hyd" />
+  </body>
+</html>

--- a/apps/vite/e2e/generate-reports.mjs
+++ b/apps/vite/e2e/generate-reports.mjs
@@ -17,7 +17,8 @@ const keep = (file) => {
   const norm = file.replaceAll("\\", "/");
   return (
     norm.endsWith("packages/ds/components/tabs.tsx") ||
-    norm.endsWith("packages/ds/components/ds-tabs.ts")
+    norm.endsWith("packages/ds/components/ds-tabs.ts") ||
+    norm.endsWith("packages/ds/components/modal.tsx")
   );
 };
 

--- a/apps/vite/e2e/tests/modal/controlled.spec.ts
+++ b/apps/vite/e2e/tests/modal/controlled.spec.ts
@@ -12,7 +12,9 @@ const dialog = (page: import("../../helpers/fixture").Page) =>
 test("starts closed; the in-modal trigger opens it and syncs state", async ({
   page,
 }) => {
-  await expect(page.locator('[data-testid="cmodal-state"]')).toHaveText("false");
+  await expect(page.locator('[data-testid="cmodal-state"]')).toHaveText(
+    "false",
+  );
   await expect(dialog(page)).toBeHidden();
   await page.locator('[data-testid="cmodal-trigger"]').click();
   await expect(dialog(page)).toBeVisible();
@@ -35,5 +37,7 @@ test("Escape closes it and reports back through onOpenChange", async ({
   await expect(dialog(page)).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(dialog(page)).toBeHidden();
-  await expect(page.locator('[data-testid="cmodal-state"]')).toHaveText("false");
+  await expect(page.locator('[data-testid="cmodal-state"]')).toHaveText(
+    "false",
+  );
 });

--- a/apps/vite/e2e/tests/modal/controlled.spec.ts
+++ b/apps/vite/e2e/tests/modal/controlled.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "../../helpers/fixture";
+
+// Controlled modal: `open` is React state, `onOpenChange` mirrors the native
+// toggle (user + programmatic).
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+});
+
+const dialog = (page: import("../../helpers/fixture").Page) =>
+  page.locator('[data-testid="cmodal"] dialog');
+
+test("starts closed; the in-modal trigger opens it and syncs state", async ({
+  page,
+}) => {
+  await expect(page.locator('[data-testid="cmodal-state"]')).toHaveText("false");
+  await expect(dialog(page)).toBeHidden();
+  await page.locator('[data-testid="cmodal-trigger"]').click();
+  await expect(dialog(page)).toBeVisible();
+  // onOpenChange (native toggle) drove React state to open.
+  await expect(page.locator('[data-testid="cmodal-state"]')).toHaveText("true");
+});
+
+test("an external button opens it programmatically (open prop drives it)", async ({
+  page,
+}) => {
+  await page.locator('[data-testid="cmodal-ext-open"]').click();
+  await expect(dialog(page)).toBeVisible();
+  await expect(page.locator('[data-testid="cmodal-state"]')).toHaveText("true");
+});
+
+test("Escape closes it and reports back through onOpenChange", async ({
+  page,
+}) => {
+  await page.locator('[data-testid="cmodal-trigger"]').click();
+  await expect(dialog(page)).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(dialog(page)).toBeHidden();
+  await expect(page.locator('[data-testid="cmodal-state"]')).toHaveText("false");
+});

--- a/apps/vite/e2e/tests/modal/modal.spec.ts
+++ b/apps/vite/e2e/tests/modal/modal.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "../../helpers/fixture";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+});
+
+const dialog = (page: import("../../helpers/fixture").Page) =>
+  page.locator('[data-testid="modal"] dialog');
+
+test("trigger opens the dialog", async ({ page }) => {
+  await expect(dialog(page)).toBeHidden();
+  await page.locator('[data-testid="open"]').click();
+  await expect(dialog(page)).toBeVisible();
+});
+
+test("the Done button closes it", async ({ page }) => {
+  await page.locator('[data-testid="open"]').click();
+  await expect(dialog(page)).toBeVisible();
+  await page.locator('[data-testid="done"]').click();
+  await expect(dialog(page)).toBeHidden();
+});
+
+test("Escape closes it", async ({ page }) => {
+  await page.locator('[data-testid="open"]').click();
+  await expect(dialog(page)).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(dialog(page)).toBeHidden();
+});
+
+test("has an accessible name", async ({ page }) => {
+  await expect(dialog(page)).toHaveAttribute("aria-labelledby", /.+/);
+  await page.locator('[data-testid="open"]').click();
+  await expect(
+    dialog(page).getByRole("heading", { name: "Account settings" }),
+  ).toBeVisible();
+});

--- a/apps/vite/src/main.tsx
+++ b/apps/vite/src/main.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { createRoot } from "react-dom/client";
 import "@repo/ds/style.css";
-import { Tabs } from "@repo/ds";
+import "@repo/ds/components/modal.css";
+import { Modal, Tabs } from "@repo/ds";
 
 const Uncontrolled = () => {
   const [last, setLast] = useState("");
@@ -76,6 +77,50 @@ const Controlled = () => {
   );
 };
 
+const ModalDemo = () => (
+  <div data-testid="modal">
+    <Modal.Root>
+      <Modal.Trigger data-testid="open">Open</Modal.Trigger>
+      <Modal.Content>
+        <Modal.Title>Account settings</Modal.Title>
+        <Modal.Description>Make changes to your account here.</Modal.Description>
+        <div style={{ padding: "0 16px 16px" }}>
+          <Modal.Close data-testid="done">Done</Modal.Close>
+        </div>
+      </Modal.Content>
+    </Modal.Root>
+  </div>
+);
+
+const ControlledModal = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div data-testid="cmodal">
+      <p>
+        Open: <strong data-testid="cmodal-state">{String(open)}</strong>{" "}
+        {/* Drives the modal from outside, programmatically. */}
+        <button
+          type="button"
+          data-testid="cmodal-ext-open"
+          onClick={() => setOpen(true)}
+        >
+          Open externally
+        </button>
+      </p>
+      <Modal.Root open={open} onOpenChange={setOpen}>
+        <Modal.Trigger data-testid="cmodal-trigger">Open</Modal.Trigger>
+        <Modal.Content>
+          <Modal.Title>Controlled</Modal.Title>
+          <Modal.Description>Driven by React state.</Modal.Description>
+          <div style={{ padding: "0 16px 16px" }}>
+            <Modal.Close data-testid="cmodal-done">Done</Modal.Close>
+          </div>
+        </Modal.Content>
+      </Modal.Root>
+    </div>
+  );
+};
+
 const App = () => (
   <div>
     <h2>Uncontrolled</h2>
@@ -83,6 +128,12 @@ const App = () => (
 
     <h2>Controlled</h2>
     <Controlled />
+
+    <h2>Modal</h2>
+    <ModalDemo />
+
+    <h2>Controlled Modal</h2>
+    <ControlledModal />
   </div>
 );
 

--- a/apps/vite/src/main.tsx
+++ b/apps/vite/src/main.tsx
@@ -83,7 +83,9 @@ const ModalDemo = () => (
       <Modal.Trigger data-testid="open">Open</Modal.Trigger>
       <Modal.Content>
         <Modal.Title>Account settings</Modal.Title>
-        <Modal.Description>Make changes to your account here.</Modal.Description>
+        <Modal.Description>
+          Make changes to your account here.
+        </Modal.Description>
         <div style={{ padding: "0 16px 16px" }}>
           <Modal.Close data-testid="done">Done</Modal.Close>
         </div>

--- a/packages/ds/components/index.ts
+++ b/packages/ds/components/index.ts
@@ -1,1 +1,2 @@
 export * as Tabs from "./tabs";
+export * as Modal from "./modal";

--- a/packages/ds/components/modal.css
+++ b/packages/ds/components/modal.css
@@ -1,0 +1,28 @@
+.ds-modal {
+  margin: auto;
+  padding: 0;
+  border: 0;
+  width: 100%;
+  max-width: 520px;
+  max-height: 85vh;
+  overflow-y: auto;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #1a1a1a;
+}
+
+.ds-modal::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.ds-modal-title {
+  margin: 0;
+  padding: 16px 16px 8px;
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.ds-modal-description {
+  margin: 0;
+  padding: 0 16px 16px;
+}

--- a/packages/ds/components/modal.md
+++ b/packages/ds/components/modal.md
@@ -14,7 +14,7 @@ with **no JavaScript**.
 ## Optionally controlled
 
 Uncontrolled needs no JS. As an opt-in JS layer over the same native element, `Root` accepts
-`onOpenChange` (wired with the `<dialog>`'s synthetic `onToggle`, so it reports user *and*
+`onOpenChange` (wired with the `<dialog>`'s synthetic `onToggle`, so it reports user _and_
 programmatic open/close with no effect) and `open` (drives the popover via
 `showPopover()`/`hidePopover()` - the one unavoidable effect, isolated in `useControlledPopover`,
 since the Popover API has no declarative open prop). The triggers keep working natively even

--- a/packages/ds/components/modal.md
+++ b/packages/ds/components/modal.md
@@ -1,0 +1,36 @@
+# Modal
+
+A compound `Modal` API (`Root` / `Trigger` / `Content` / `Title` / `Description` / `Close`)
+backed by a native [`<dialog popover>`](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)
+with **no JavaScript**.
+
+- **Open** via `popovertarget` on the `Trigger`; **close** via `popovertargetaction="hide"` on
+  `Close`. **Escape** and **outside-click** dismissal are native.
+- The `popovertarget` <-> `id` wiring is emitted in the SSR markup, so the trigger works
+  **before or without hydration**.
+- Accessible name/description via `useId`: `Title`/`Description` supply the `id`s that `Content`
+  references with `aria-labelledby`/`aria-describedby`; `<dialog>` provides `role="dialog"`.
+
+## Optionally controlled
+
+Uncontrolled needs no JS. As an opt-in JS layer over the same native element, `Root` accepts
+`onOpenChange` (wired with the `<dialog>`'s synthetic `onToggle`, so it reports user *and*
+programmatic open/close with no effect) and `open` (drives the popover via
+`showPopover()`/`hidePopover()` - the one unavoidable effect, isolated in `useControlledPopover`,
+since the Popover API has no declarative open prop). The triggers keep working natively even
+when controlled - React just observes and can also drive it.
+
+## Intentionally non-modal
+
+`popover="auto"` is a supplemental/contextual overlay - the background stays interactive (no
+focus trap), per [Hidde de Vries on dialog vs popover](https://hidde.blog/dialog-modal-popover-differences/)
+and the project's "reach for the least disruptive pattern" principle. Reach for a true modal
+(`<dialog>` via `showModal()`) only when blocking the page is genuinely necessary.
+
+## Resources
+
+- [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)
+- [`<dialog>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)
+- [Dialog, modal and popover differences](https://hidde.blog/dialog-modal-popover-differences/) - Hidde de Vries
+- [Semantics and the popover attribute](https://hidde.blog/popover-semantics/) - Hidde de Vries
+- [Radix Primitives - Dialog](https://www.radix-ui.com/primitives/docs/components/dialog)

--- a/packages/ds/components/modal.tsx
+++ b/packages/ds/components/modal.tsx
@@ -1,0 +1,133 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useId,
+  useRef,
+} from "react";
+import "./modal.css";
+
+const ModalContext = createContext<{
+  id: string;
+  titleId: string;
+  descriptionId: string;
+  onOpenChange?: (open: boolean) => void;
+}>({ id: "ds-modal", titleId: "ds-modal-title", descriptionId: "ds-modal-desc" });
+
+// Separate from the ids context so that stays ref-free (a ref beside the ids
+// makes react-hooks/refs flag every ctx read as a render-time ref access).
+const ModalDialogRefContext =
+  createContext<React.RefObject<HTMLDialogElement | null> | null>(null);
+
+function useControlledPopover(
+  ref: React.RefObject<HTMLDialogElement | null>,
+  open: boolean | undefined,
+) {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || open === undefined) return;
+    const isOpen = el.matches(":popover-open");
+    if (open && !isOpen) el.showPopover();
+    else if (!open && isOpen) el.hidePopover();
+  }, [ref, open]);
+}
+
+export const Root: React.FC<{
+  children?: React.ReactNode;
+  id?: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}> = ({ children, id, open, onOpenChange }) => {
+  const autoId = useId().replace(/:/g, "-");
+  const base = id ?? autoId;
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  useControlledPopover(dialogRef, open);
+
+  return (
+    <ModalContext.Provider
+      value={{
+        id: base,
+        titleId: `${base}-title`,
+        descriptionId: `${base}-desc`,
+        onOpenChange,
+      }}
+    >
+      <ModalDialogRefContext.Provider value={dialogRef}>
+        {children}
+      </ModalDialogRefContext.Provider>
+    </ModalContext.Provider>
+  );
+};
+
+export const Trigger: React.FC<
+  React.ButtonHTMLAttributes<HTMLButtonElement> & { id?: string }
+> = ({ children, id, ...rest }) => {
+  const ctx = useContext(ModalContext);
+  return (
+    <button type="button" popoverTarget={id ?? ctx.id} {...rest}>
+      {children}
+    </button>
+  );
+};
+
+export const Content: React.FC<{
+  children?: React.ReactNode;
+  id?: string;
+  className?: string;
+}> = ({ children, id, className }) => {
+  const ctx = useContext(ModalContext);
+  const dialogRef = useContext(ModalDialogRefContext);
+  return (
+    <dialog
+      ref={dialogRef}
+      id={id ?? ctx.id}
+      popover="auto"
+      aria-labelledby={ctx.titleId}
+      aria-describedby={ctx.descriptionId}
+      className={className ? `ds-modal ${className}` : "ds-modal"}
+      onToggle={(e) =>
+        ctx.onOpenChange?.(e.currentTarget.matches(":popover-open"))
+      }
+    >
+      {children}
+    </dialog>
+  );
+};
+
+export const Title: React.FC<{ children?: React.ReactNode }> = ({
+  children,
+}) => {
+  const ctx = useContext(ModalContext);
+  return (
+    <h2 id={ctx.titleId} className="ds-modal-title">
+      {children}
+    </h2>
+  );
+};
+
+export const Description: React.FC<{ children?: React.ReactNode }> = ({
+  children,
+}) => {
+  const ctx = useContext(ModalContext);
+  return (
+    <p id={ctx.descriptionId} className="ds-modal-description">
+      {children}
+    </p>
+  );
+};
+
+export const Close: React.FC<
+  React.ButtonHTMLAttributes<HTMLButtonElement> & { id?: string }
+> = ({ children, id, ...rest }) => {
+  const ctx = useContext(ModalContext);
+  return (
+    <button
+      type="button"
+      popoverTarget={id ?? ctx.id}
+      popoverTargetAction="hide"
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};

--- a/packages/ds/components/modal.tsx
+++ b/packages/ds/components/modal.tsx
@@ -12,7 +12,11 @@ const ModalContext = createContext<{
   titleId: string;
   descriptionId: string;
   onOpenChange?: (open: boolean) => void;
-}>({ id: "ds-modal", titleId: "ds-modal-title", descriptionId: "ds-modal-desc" });
+}>({
+  id: "ds-modal",
+  titleId: "ds-modal-title",
+  descriptionId: "ds-modal-desc",
+});
 
 // Separate from the ids context so that stays ref-free (a ref beside the ids
 // makes react-hooks/refs flag every ctx read as a render-time ref access).

--- a/packages/ds/package.json
+++ b/packages/ds/package.json
@@ -6,7 +6,9 @@
     "./style.css": "./style.css",
     "./components/tabs.css": "./components/tabs.css",
     "./tabs": "./components/tabs.tsx",
-    "./tabs/define": "./components/ds-tabs.ts"
+    "./tabs/define": "./components/ds-tabs.ts",
+    "./components/modal.css": "./components/modal.css",
+    "./modal": "./components/modal.tsx"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
A compound Modal (`Root`/`Trigger`/`Content`/`Title`/`Description`/`Close`) backed by a native `<dialog popover>`.

- **No JS / uncontrolled by default:** open via `popovertarget`, close via `popovertargetaction="hide"`; Escape and outside-click are native. Wiring is in SSR markup, so it works before/without hydration.
- **Optional controlled mode:** `onOpenChange` (wired through the dialog's synthetic `onToggle`, no effect) and `open` (the one unavoidable effect, isolated in `useControlledPopover`, since the Popover API has no declarative open prop).
- Astro + Vite demos and Playwright tests, including modal-in-modal (asserted on the un-hydrated instance) and a `/test/modal` entry in the hydration-warning suite.

**Stacked on #13** (needs the hydration-warning + coverage tooling). Base is `test/hydration-coverage`; retarget to `main` once #13 merges.