### PR TITLE
Deploy astro, vite, and 11ty examples to GitHub Pages

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Design System APIs</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family:
+          system-ui,
+          -apple-system,
+          Segoe UI,
+          Roboto,
+          Helvetica,
+          Arial,
+          sans-serif;
+        line-height: 1.5;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 2rem;
+      }
+      main {
+        width: 100%;
+        max-width: 40rem;
+      }
+      h1 {
+        margin: 0 0 0.25rem;
+      }
+      p.lede {
+        margin: 0 0 2rem;
+        opacity: 0.8;
+      }
+      ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 1rem;
+      }
+      a.card {
+        display: block;
+        padding: 1.25rem 1.5rem;
+        border: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+        border-radius: 12px;
+        text-decoration: none;
+        color: inherit;
+      }
+      a.card:hover {
+        border-color: color-mix(in srgb, currentColor 45%, transparent);
+      }
+      a.card strong {
+        font-size: 1.15rem;
+      }
+      a.card span {
+        display: block;
+        opacity: 0.75;
+        font-size: 0.95rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>React Design System APIs</h1>
+      <p class="lede">
+        One design system (a progressively-enhanced Tabs component) consumed
+        across three build tools. Each demo is a static site.
+      </p>
+      <ul>
+        <li>
+          <a class="card" href="astro/">
+            <strong>Astro</strong>
+            <span>Static HTML with React islands (SSG + hydration)</span>
+          </a>
+        </li>
+        <li>
+          <a class="card" href="vite/">
+            <strong>Vite</strong>
+            <span>Client-rendered React single-page app</span>
+          </a>
+        </li>
+        <li>
+          <a class="card" href="11ty/">
+            <strong>Eleventy</strong>
+            <span>No framework — the custom element and CSS only</span>
+          </a>
+        </li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,79 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Least privilege for the build; Pages deploy needs pages + id-token.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deploy at a time; don't cancel an in-flight deploy.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Each app is served from a sub-path of the project site
+    # (https://<owner>.github.io/<repo>/), so it must be built with a matching
+    # base. BASE_PATH is read by each app's config and is set only here.
+    env:
+      REPO: ${{ github.event.repository.name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build astro
+        run: pnpm --filter astro build
+        env:
+          BASE_PATH: /${{ env.REPO }}/astro
+
+      - name: Build vite
+        run: pnpm --filter vite build
+        env:
+          BASE_PATH: /${{ env.REPO }}/vite/
+
+      - name: Build 11ty
+        run: pnpm --filter 11ty build
+        env:
+          BASE_PATH: /${{ env.REPO }}/11ty/
+
+      - name: Assemble Pages site
+        run: |
+          mkdir -p _site
+          cp .github/pages/index.html _site/index.html
+          cp -r apps/astro/dist _site/astro
+          cp -r apps/vite/dist _site/vite
+          cp -r apps/11ty/dist _site/11ty
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/apps/11ty/eleventy.config.js
+++ b/apps/11ty/eleventy.config.js
@@ -2,11 +2,16 @@ import "tsx/esm";
 import { register } from "node:module";
 import { renderToStaticMarkup } from "react-dom/server";
 import * as esbuild from "esbuild";
+import { EleventyHtmlBasePlugin } from "@11ty/eleventy";
 
 // Registered after tsx/esm so it sits outermost and delegates non-CSS to tsx.
 register("./lib/css-loader.js", import.meta.url);
 
 export default function (eleventyConfig) {
+  // Rewrites the absolute href/src URLs in the SSR'd HTML to respect pathPrefix,
+  // so the site works when deployed under a GitHub Pages sub-path.
+  eleventyConfig.addPlugin(EleventyHtmlBasePlugin);
+
   eleventyConfig.addTemplateFormats("11ty.jsx,11ty.ts,11ty.tsx");
   eleventyConfig.addExtension(["11ty.jsx", "11ty.ts", "11ty.tsx"], {
     key: "11ty.js",
@@ -34,5 +39,9 @@ export default function (eleventyConfig) {
     });
   });
 
-  return { dir: { input: "src", output: "dist" } };
+  return {
+    // BASE_PATH is set only by the Pages workflow; unset locally so links stay at "/".
+    pathPrefix: process.env.BASE_PATH || "/",
+    dir: { input: "src", output: "dist" },
+  };
 }

--- a/apps/astro/astro.config.mjs
+++ b/apps/astro/astro.config.mjs
@@ -8,8 +8,13 @@ import react from "@astrojs/react";
 // the console-assertion test can catch them.
 const devReact = process.env.E2E_DEV_REACT === "true";
 
+// Deploys under a sub-path on GitHub Pages (e.g. /react-design-system-apis/astro/).
+// BASE_PATH is set only by the Pages workflow; unset locally so dev/e2e stay at "/".
+const base = process.env.BASE_PATH;
+
 // https://astro.build/config
 export default defineConfig({
+  base,
   integrations: [react()],
   vite: {
     // Emit source maps so Playwright V8 coverage maps the built _astro chunks

--- a/apps/astro/src/pages/index.astro
+++ b/apps/astro/src/pages/index.astro
@@ -1,11 +1,15 @@
 ---
+// Join BASE_URL (astro's configured `base`, "/" locally) with the route so the
+// link is correct both at the root and under a Pages sub-path.
+const base = import.meta.env.BASE_URL;
+const tabsHref = `${base.replace(/\/$/, "")}/tabs`;
 ---
 
 <html lang="en">
   <body>
     <h1>React Design System APIs</h1>
     <ul>
-      <li><a href="/tabs">Tabs</a></li>
+      <li><a href={tabsHref}>Tabs</a></li>
     </ul>
   </body>
 </html>

--- a/apps/vite/index.html
+++ b/apps/vite/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
   </head>

--- a/apps/vite/vite.config.ts
+++ b/apps/vite/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  // Deploys under a sub-path on GitHub Pages (e.g. /react-design-system-apis/vite/).
+  // BASE_PATH is set only by the Pages workflow; unset locally so dev/e2e stay at "/".
+  base: process.env.BASE_PATH || "/",
   plugins: [react()],
   build: {
     sourcemap: true,


### PR DESCRIPTION
## What

Deploys the three example apps as static sites to GitHub Pages on every push to `main`, each in its own subfolder under a landing page:

- `/astro/` — static HTML with React islands (SSG + hydration)
- `/vite/` — client-rendered React SPA
- `/11ty/` — **new**: the design system consumed with no framework (the `<ds-tabs>` custom element + CSS only)

Site root: `https://penx.github.io/react-design-system-apis/`

## Changes

- **New `apps/11ty` (Eleventy).** The no-React consumer. Eleventy renders static markup; esbuild (via an `eleventy.before` hook) bundles `@repo/ds/tabs/define` + DS CSS into `_site/assets/`. Exercises the progressive-enhancement floor: a no-JS radio group that upgrades to a WAI-ARIA tablist. Bundle is ~3 KB with no React pulled in.
- **Sub-path base paths** for all three, driven by a `BASE_PATH` env var set *only* by the workflow, so local dev/e2e stay at `/`. Astro `base`, Vite `base`, Eleventy `pathPrefix`.
- Astro's hardcoded `/tabs` index link is now base-aware; removed the dead `/vite.svg` favicon link (no such file — 404 on every load).
- `.github/workflows/deploy.yml` — builds each app with its base, assembles into subfolders + a root landing page (`.github/pages/index.html`), deploys via `upload-pages-artifact` + `deploy-pages`.
- `turbo.json` — `_site/**` added to build outputs.

## Verification

- `format:check`, `lint`, and default `pnpm build` (all 3 apps) pass.
- Rebuilt all three with Pages base paths, assembled under the real `/react-design-system-apis/` sub-path, served locally, and drove them in a headless browser: landing links resolve and Tabs work in all three with zero 4xx/failed asset requests — including the 11ty element upgrading to `role="tablist"` and switching panels.

## Note

Repo **Pages → Source** must be set to **GitHub Actions** (done).